### PR TITLE
[FEAT] make the /ping command actually send the bot's ping

### DIFF
--- a/les-copaings/src/commands/ping.go
+++ b/les-copaings/src/commands/ping.go
@@ -25,7 +25,7 @@ func Ping(client *discordgo.Session, i *discordgo.InteractionCreate) {
 	interactionTimestamp, err := utils.GetTimestampFromId(i.ID)
 	if err != nil {
 		utils.SendAlert("ping.go - Get timestamp from ID", err.Error())
-		msg = "� Pong !"
+		msg = ":ping_pong: Pong !"
 	} else {
 		utils.SendDebug(interactionTimestamp.Format(time.UnixDate))
 		msg = fmt.Sprintf(

--- a/les-copaings/src/commands/ping.go
+++ b/les-copaings/src/commands/ping.go
@@ -1,13 +1,45 @@
 package commands
 
 import (
+	"fmt"
 	"github.com/anhgelus/discord-bots/les-copaings/src/utils"
 	"github.com/bwmarrin/discordgo"
+	"time"
 )
 
 func Ping(client *discordgo.Session, i *discordgo.InteractionCreate) {
-	err := respondInteraction(client, i, "Pong !")
+	err := client.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+	})
 	if err != nil {
 		utils.SendAlert("ping.go - Respond interaction", err.Error())
+	}
+
+	response, err := client.InteractionResponse(i.Interaction)
+	if err != nil {
+		utils.SendAlert("ping.go - Interaction response", err.Error())
+	}
+
+	var msg string
+
+	interactionTimestamp, err := utils.GetTimestampFromId(i.ID)
+	if err != nil {
+		utils.SendAlert("ping.go - Get timestamp from ID", err.Error())
+		msg = "� Pong !"
+	} else {
+		utils.SendDebug(interactionTimestamp.Format(time.UnixDate))
+		msg = fmt.Sprintf(
+			":ping_pong: Pong !\nLatence du bot : `%d ms`\nLatence de l'API discord : `%d ms`",
+			response.Timestamp.Sub(interactionTimestamp).Milliseconds(),
+			client.HeartbeatLatency().Milliseconds(),
+		)
+	}
+
+	_, err = client.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: &msg,
+	})
+
+	if err != nil {
+		utils.SendAlert("ping.go - Interaction response edit", err.Error())
 	}
 }

--- a/les-copaings/src/init/bot.go
+++ b/les-copaings/src/init/bot.go
@@ -81,7 +81,7 @@ func initCommands() {
 	cmds = append(cmds, Cmd{
 		ApplicationCommand: discordgo.ApplicationCommand{
 			Name:        "ping",
-			Description: "Juste un ping",
+			Description: "Obtenez le ping du bot",
 		},
 		Handler: cmd.Ping,
 	}, Cmd{

--- a/les-copaings/src/utils/discordgo.go
+++ b/les-copaings/src/utils/discordgo.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"github.com/bwmarrin/discordgo"
+	"strconv"
+	"time"
 )
 
 func FetchGuildUser(s *discordgo.Session, guildID string) []*discordgo.Member {
@@ -10,4 +12,16 @@ func FetchGuildUser(s *discordgo.Session, guildID string) []*discordgo.Member {
 		SendAlert("discordgo.go - Failed to fetch guild users", err.Error())
 	}
 	return member
+}
+
+func GetTimestampFromId(id string) (time.Time, error) {
+	idInt, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return time.UnixMilli(0), err
+	}
+
+	// https://discord.com/developers/docs/reference#snowflakes-snowflake-id-format-structure-left-to-right
+	timestamp := (idInt >> 22) + 1420070400000
+
+	return time.UnixMilli(timestamp), nil
 }


### PR DESCRIPTION
What's the point of having a ping command if it doesn't send the bot's ping/latency ? 

I decided to fix this by enhancing the /ping command, the most important commands of all.

Here's how it looks :
![image](https://github.com/anhgelus/discord-bots/assets/80011647/4c3289b2-08f1-40ee-a058-8bda1536def1)
